### PR TITLE
ci: Add Continuous Integration

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -1,0 +1,33 @@
+name: 'CodeQL'
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '35 21 * * 5'
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ['javascript']
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v2
+        with:
+          languages: ${{ matrix.language }}
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v2
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v2

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -17,4 +17,4 @@ jobs:
           node-version: 16
           cache: 'npm'
       - run: npm install
-      - run: npm run test
+      - run: npm test

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,20 @@
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [assigned, opened, synchronize, reopened]
+
+name: Main
+jobs:
+  Test:
+    name: 'Test'
+    runs-on: 'ubuntu-latest'
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: 'npm'
+      - run: npm install
+      - run: npm run test


### PR DESCRIPTION
🍣 Context / problem
There is no Continuous Integration yet. It is a [software development good practice](https://about.gitlab.com/blog/2015/02/03/7-reasons-why-you-should-be-using-ci/).

🎯 Idea / solution
Using GitHub Actions (with [CodeQL](https://codeql.github.com/) integration) to automatically run testing, linting, scanning, vulnerability checking, etc.

💡 Discussion / consequences
Each time a commit is pushed on a branch, then some automated checks are executed.

🤖 Tests / checks
Check that GitHub Checks are displayed and executed