### PR TITLE
Fix: corrections when deploying Paastis on Carnet de bord

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: npm run db:migrate && node src/index.js

--- a/db/config.json
+++ b/db/config.json
@@ -14,10 +14,11 @@
     "dialect": "postgres"
   },
   "production": {
-    "username": "paastis-user",
-    "password": "mysecretpassword",
-    "database": "paastis",
-    "host": "127.0.0.1",
-    "dialect": "postgres"
+    "use_env_variable": "DATABASE_URL",
+    "dialect": "postgres",
+    "ssl": true,
+    "dialectOptions": {
+      "ssl": true
+    }
   }
 }

--- a/src/Scheduler.js
+++ b/src/Scheduler.js
@@ -65,8 +65,7 @@ export default class Scheduler {
       const runningApps = await registry.listApps();
       if (runningApps) {
         console.log(
-          'Active apps: ',
-          runningApps.map((app) => app.name)
+          JSON.stringify({ active_apps: runningApps.map((app) => app.name) })
         );
       }
     } catch (err) {

--- a/src/provider/PaasProvider.js
+++ b/src/provider/PaasProvider.js
@@ -69,10 +69,10 @@ export default class PaasProvider {
               shell: true,
             });
             afterAppStart.stdout.on('data', (data) => {
-              console.log(`stdout: ${data}`);
+              console.log({ event: 'after_app_start', appId, stdout: data });
             });
             afterAppStart.stderr.on('data', (data) => {
-              console.error(`stderr: ${data}`);
+              console.error({ event: 'after_app_start', appId, stderr: data });
             });
             afterAppStart.on('close', async (code) => {
               return resolve();
@@ -92,10 +92,10 @@ export default class PaasProvider {
           shell: true,
         });
         beforeAppStart.stdout.on('data', (data) => {
-          console.log(`stdout: ${data}`);
+          console.log({ event: 'before_app_start', appId, stdout: data });
         });
         beforeAppStart.stderr.on('data', (data) => {
-          console.error(`stderr: ${data}`);
+          console.log({ event: 'before_app_start', appId, stderr: data });
         });
         beforeAppStart.on('close', (code) => {
           executeStartApp(resolve, reject);
@@ -124,10 +124,10 @@ export default class PaasProvider {
       if (config.hooks.afterAppStop) {
         const afterAppStop = spawn(config.hooks.afterAppStop, { shell: true });
         afterAppStop.stdout.on('data', (data) => {
-          console.log(`stdout: ${data}`);
+          console.log({ event: 'after_app_stop', appId, stdout: data });
         });
         afterAppStop.stderr.on('data', (data) => {
-          console.error(`stderr: ${data}`);
+          console.log({ event: 'after_app_stop', appId, stderr: data });
         });
         afterAppStop.on('close', async (code) => {
           return resolve();
@@ -142,10 +142,10 @@ export default class PaasProvider {
           shell: true,
         });
         beforeAppStop.stdout.on('data', (data) => {
-          console.log(`stdout: ${data}`);
+          console.log({ event: 'before_app_stop', appId, stdout: data });
         });
         beforeAppStop.stderr.on('data', (data) => {
-          console.error(`stderr: ${data}`);
+          console.log({ event: 'before_app_stop', appId, stderr: data });
         });
         beforeAppStop.on('close', (code) => {
           executeStopApp(resolve, reject);

--- a/src/redis.js
+++ b/src/redis.js
@@ -12,7 +12,7 @@ if (config.registry.type === 'redis') {
     });
 
     client.on('error', (err) => {
-      console.log('Redis Client Error', err);
+      console.log(JSON.stringify({ msg: 'Redis Client Error', err: err.stack }));
     });
 
     client.on('ready', () => {

--- a/src/redis.js
+++ b/src/redis.js
@@ -12,7 +12,9 @@ if (config.registry.type === 'redis') {
     });
 
     client.on('error', (err) => {
-      console.log(JSON.stringify({ msg: 'Redis Client Error', err: err.stack }));
+      console.log(
+        JSON.stringify({ msg: 'Redis Client Error', err: err.stack })
+      );
     });
 
     client.on('ready', () => {

--- a/src/router/upstream.js
+++ b/src/router/upstream.js
@@ -37,5 +37,14 @@ export default async (req, res) => {
   } else {
     upstream = `https://${appKey}.osc-fr1.scalingo.io`;
   }
+
+  // Rewrite the Origin header, but only if it matches the Host header, to
+  // avoid creating a CORS vulnerbility
+  const originIsHost = req.headers.origin === url.origin;
+
+  if (originIsHost) {
+    req.headers['origin'] = upstream;
+  }
+
   return proxy.web(req, res, { target: upstream });
 };

--- a/src/router/upstream.js
+++ b/src/router/upstream.js
@@ -19,8 +19,13 @@ export default async (req, res) => {
   const appKeys = await registry.registerApp(appKey);
 
   // 2) Run apps
-  for (const appKey of appKeys) {
-    await provider.ensureAppIsRunning(appKey);
+  try {
+    for (const appKey of appKeys) {
+      await provider.ensureAppIsRunning(appKey);
+    }
+  } catch (err) {
+    console.log({ msg:'error starting app', appKey, err: err.stack });
+    res.writeHead(500).end();
   }
 
   // 3) Redirect to upstream

--- a/src/router/upstream.js
+++ b/src/router/upstream.js
@@ -24,7 +24,7 @@ export default async (req, res) => {
       await provider.ensureAppIsRunning(appKey);
     }
   } catch (err) {
-    console.log({ msg:'error starting app', appKey, err: err.stack });
+    console.log({ msg: 'error starting app', appKey, err: err.stack });
     res.writeHead(500).end();
   }
 


### PR DESCRIPTION
## :wrench: Problem

[Carnet de bord](https://github.com/gip-inclusion/carnet-de-bord) tests Paastis for their development environments, on Scalingo.

They have some interesting things / constraints : 
- each app is composed of : 
  - 1 front-end webapp on Sveltekit
  - 1 back-end app in FastAPI (Python)
  - 1 back-for-front based on Hasura
- they do not use as-is the auto deploy on each PR : 
  - they use a custom script
  - they use the manual deployment allowed by GitHub / Scalingo
- Svelte is really cautionous about CSRF and CORS

## :cake: Solution

This PR contains : 
- use a Procfile instead of `npm start` to not be polluted by npm logs
- Inline console logs by displaying JSON strings / objects
- fix `DATABASE_URL` varenv for production environment
- do not crash when Scalingo action on apps fails (ex : when token is outdated, or when the app does not exist anymore, etc.)
